### PR TITLE
Phase 3: Automated Attack Execution

### DIFF
--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -316,3 +316,98 @@ Open questions for Phase 3:
   shared cache/persistence utility without changing saved artifact formats.
 - Ensure `AttackRunner` consumes LLM08 structured entries correctly, including `target_query`,
   `poisoned_doc_content`, similarity thresholds, and retrieval metadata.
+
+---
+
+## Phase 3 — Automated Attack Execution
+
+**Branch:** `feat/phase-3-attack-runner`
+**Status:** In progress
+
+### 3.1 Runner architecture
+
+Phase 3 introduces the canonical `src/pipeline/` execution layer:
+
+- `attack_runner.py`: async `AttackRunner`, result schema, dataset selection, Typer CLI.
+- `cache.py`: SQLite result cache promoted from Phase 1's per-entry checkpoint pattern.
+- `rate_limiter.py`: async token-bucket limiter plus semaphore-based concurrency.
+- `retry.py`: capped transient-error retry policy.
+- `llm08_executor.py`: LLM08 retrieval-layer execution path.
+
+The runner is async throughout. `AttackRunner` uses `asyncio.Semaphore` with default concurrency 5,
+but target-model calls still pass through a token bucket before execution.
+
+### 3.2 Cache and invalidation
+
+Cache location is `cache/results_cache.sqlite` (gitignored). Writes happen per result immediately
+after each attack finishes, preserving the Phase 1 lost-work lesson. Cache key:
+
+`(attack_id, target_model, target_version, prompt_hash)`
+
+`target_version` hashes target model, system prompt, prompt template, and retrieval config. The
+retrieval config includes `top_k`, embedding model, and search type so RAG behavior changes
+invalidate old target responses. The cache includes a `cache_schema_version` table; unknown schema
+versions fail closed instead of silently reading incompatible data.
+
+Infrastructure failures are recorded as structured result entries with
+`status="infrastructure_failure"` rather than being omitted from `results.jsonl`. This keeps run
+completeness auditable and allows cheap retries because successful prior rows remain cached.
+
+### 3.3 Rate limiting and retry
+
+Groq's target-model quota for `llama-3.1-8b-instant` is treated as 30 RPM. The rate limiter uses:
+
+- `rate_per_minute=30`
+- `burst=2`
+- default runner concurrency 5
+
+The burst is intentionally 2, not 5, because a concurrency-sized burst can fire several calls inside
+one rolling-window second and invite avoidable 429s.
+
+Retries are capped at three attempts after the initial call: 1s, 2s, then 4s. `Retry-After` is
+honored when present. After retry exhaustion, the result is recorded as `infrastructure_failure`.
+The short cap avoids long wall-clock stalls during sustained 429 storms; per-result caching makes
+reruns cheap.
+
+### 3.4 LLM08 execution
+
+LLM08 entries are structured retrieval attacks, so they do not all use the normal `aquery()` path.
+`llm08_executor.py` owns the special behavior:
+
+- `embedding_poisoning`: deep-copy the loaded FAISS vectorstore with `copy.deepcopy()`, add the
+  poisoned document to the in-memory copy, query that copy, and tear it down. The on-disk index is
+  never saved or mutated.
+- `similarity_collision`: query the normal target and record whether `target_doc_id` was retrieved.
+- `retrieval_boundary_probing` and `embedding_inversion`: standard target query with additional
+  retrieved-document diagnostics.
+
+LLM08 result extras:
+
+- `llm08_retrieved_docs`: retrieved docs with `doc_id`, `source`, FAISS L2 `distance`, approximate
+  `similarity = 1 / (1 + distance)`, and content.
+- `llm08_checks`: strategy-specific booleans such as `poisoned_doc_retrieved` and
+  `target_doc_retrieved`.
+
+Important metric note: LangChain FAISS `similarity_search_with_score()` returns L2 distance, where
+lower means more similar. The result field is named `distance` to avoid Phase 4 confusing it with a
+cosine-style score.
+
+### 3.5 CLI and sampling
+
+The Typer CLI lives in `src.pipeline.attack_runner`:
+
+```bash
+uv run python -m src.pipeline.attack_runner run --dry-run
+uv run python -m src.pipeline.attack_runner run --sample 5
+uv run python -m src.pipeline.attack_runner run --category LLM01
+```
+
+Dry-run mode loads and filters the dataset but does not instantiate `RAGChatbot`, open the cache, or
+make API calls. Sampling is deterministic and stratified across categories for repeatable dev runs.
+
+### 3.6 LangSmith tracing
+
+LangSmith remains controlled by environment configuration and defaults off in CI to preserve the
+5k/month free quota. Phase 3 result records already include attack IDs, OWASP categories, retrieved
+chunks, document IDs, and response text so Phase 4 can add richer trace tags without changing the
+result artifact shape.

--- a/src/pipeline/attack_runner.py
+++ b/src/pipeline/attack_runner.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import asyncio
 import json
 import random
+import re
 from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Annotated, Any, Protocol
 
 import structlog
+import typer
 from pydantic import BaseModel, ConfigDict, Field
 
 from src.pipeline.cache import ResultCache, build_target_version, hash_text
@@ -27,9 +29,21 @@ if TYPE_CHECKING:
 log = structlog.get_logger()
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_DEFAULT_DATASET_PATH = _PROJECT_ROOT / "attacks" / "v1" / "dataset.jsonl"
+_DEFAULT_CACHE_PATH = _PROJECT_ROOT / "cache" / "results_cache.sqlite"
 _DEFAULT_RESULTS_ROOT = _PROJECT_ROOT / "results"
 _DEFAULT_TARGET_MODEL = "llama-3.1-8b-instant"
 _DEFAULT_EMBEDDING_MODEL = "all-MiniLM-L6-v2"
+_CATEGORY_RE = re.compile(r"^LLM\d{2}(?::2025)?$")
+
+app = typer.Typer(add_completion=False)
+
+DatasetPathOption = Annotated[Path, typer.Option("--dataset")]
+CachePathOption = Annotated[Path, typer.Option("--cache")]
+ConcurrencyOption = Annotated[int, typer.Option("--concurrency")]
+SampleOption = Annotated[int | None, typer.Option("--sample", min=1)]
+CategoryOption = Annotated[str | None, typer.Option("--category")]
+DryRunOption = Annotated[bool, typer.Option("--dry-run")]
 
 
 class AsyncTargetSystem(Protocol):
@@ -68,6 +82,7 @@ class AttackRunner:
         cache_path: Path | str,
         concurrency: int = 5,
         dry_run_sample_n: int | None = None,
+        category: str | None = None,
         results_root: Path | str = _DEFAULT_RESULTS_ROOT,
         rate_limiter: TokenBucketRateLimiter | None = None,
         retry_sleeper: Callable[[float], Awaitable[None]] = asyncio.sleep,
@@ -82,6 +97,7 @@ class AttackRunner:
         self.cache = ResultCache(cache_path)
         self.concurrency = concurrency
         self.dry_run_sample_n = dry_run_sample_n
+        self.category = _normalize_category(category) if category else None
         self.results_root = Path(results_root)
         self.rate_limiter = rate_limiter or TokenBucketRateLimiter(rate_per_minute=30, burst=2)
         self.retry_sleeper = retry_sleeper
@@ -91,9 +107,11 @@ class AttackRunner:
 
     async def run(self) -> list[AttackResult]:
         """Run attacks, persist JSONL results, and return structured records."""
-        attacks = self._load_dataset()
-        if self.dry_run_sample_n is not None:
-            attacks = _stratified_sample(attacks, self.dry_run_sample_n)
+        attacks = select_attacks(
+            self._load_dataset(),
+            sample_n=self.dry_run_sample_n,
+            category=self.category,
+        )
 
         results = await self._run_attacks(attacks)
         self._write_results(results)
@@ -239,10 +257,45 @@ def _stratified_sample(attacks: Sequence[dict[str, Any]], n: int) -> list[dict[s
     return selected
 
 
+def load_dataset(path: Path | str) -> list[dict[str, Any]]:
+    dataset_path = Path(path)
+    if not dataset_path.exists():
+        raise FileNotFoundError(f"dataset not found: {dataset_path}")
+    return [
+        json.loads(line)
+        for line in dataset_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def select_attacks(
+    attacks: Sequence[dict[str, Any]],
+    *,
+    sample_n: int | None = None,
+    category: str | None = None,
+) -> list[dict[str, Any]]:
+    selected = list(attacks)
+    if category:
+        normalized = _normalize_category(category)
+        selected = [attack for attack in selected if attack["owasp_category"] == normalized]
+    if sample_n is not None:
+        selected = _stratified_sample(selected, sample_n)
+    return selected
+
+
 def _attack_prompt_hash(attack: dict[str, Any]) -> str:
     if attack.get("owasp_category") == "LLM08:2025":
         return hash_text(json.dumps(attack, sort_keys=True, default=str))
     return hash_text(str(attack["prompt_text"]))
+
+
+def _normalize_category(category: str) -> str:
+    value = category.upper()
+    if not _CATEGORY_RE.match(value):
+        raise ValueError("category must look like LLM01 or LLM01:2025")
+    if ":" not in value:
+        value = f"{value}:2025"
+    return value
 
 
 def _target_model(target_system: AsyncTargetSystem) -> str:
@@ -269,3 +322,50 @@ def _target_version(target_system: AsyncTargetSystem, target_model: str) -> str:
 
 def _utc_now() -> str:
     return datetime.now(UTC).isoformat()
+
+
+@app.command()
+def run(
+    dataset_path: DatasetPathOption = _DEFAULT_DATASET_PATH,
+    cache_path: CachePathOption = _DEFAULT_CACHE_PATH,
+    concurrency: ConcurrencyOption = 5,
+    sample: SampleOption = None,
+    category: CategoryOption = None,
+    dry_run: DryRunOption = False,
+) -> None:
+    """Run Phase 3 attack execution."""
+    attacks = select_attacks(load_dataset(dataset_path), sample_n=sample, category=category)
+    if dry_run:
+        typer.echo(f"Dry run: {len(attacks)} attack(s) would execute")
+        for attack in attacks:
+            typer.echo(f"{attack['id']}\t{attack['owasp_category']}\t{attack['attack_strategy']}")
+        return
+
+    from src.target_system.rag_chatbot import RAGChatbot
+
+    runner = AttackRunner(
+        target_system=RAGChatbot(),
+        dataset_path=dataset_path,
+        cache_path=cache_path,
+        concurrency=concurrency,
+        dry_run_sample_n=sample,
+        category=category,
+    )
+    try:
+        results = asyncio.run(runner.run())
+    finally:
+        runner.close()
+
+    statuses: dict[str, int] = defaultdict(int)
+    for result in results:
+        statuses[result.status] += 1
+    typer.echo(f"Executed {len(results)} attack(s): {dict(sorted(statuses.items()))}")
+
+
+@app.command(hidden=True)
+def _commands() -> None:
+    """Keep Typer in multi-command mode so ``run`` is explicit."""
+
+
+if __name__ == "__main__":
+    app()

--- a/src/pipeline/attack_runner.py
+++ b/src/pipeline/attack_runner.py
@@ -14,6 +14,7 @@ import structlog
 from pydantic import BaseModel, ConfigDict, Field
 
 from src.pipeline.cache import ResultCache, build_target_version, hash_text
+from src.pipeline.llm08_executor import LLM08Executor
 from src.pipeline.rate_limiter import TokenBucketRateLimiter
 from src.pipeline.retry import RetryExhaustedError, retry_transient
 from src.target_system.prompts import SYSTEM_PROMPT
@@ -84,6 +85,7 @@ class AttackRunner:
         self.results_root = Path(results_root)
         self.rate_limiter = rate_limiter or TokenBucketRateLimiter(rate_per_minute=30, burst=2)
         self.retry_sleeper = retry_sleeper
+        self.llm08_executor = LLM08Executor(target_system)
         self.target_model = _target_model(target_system)
         self.target_version = _target_version(target_system, self.target_model)
 
@@ -122,7 +124,7 @@ class AttackRunner:
     async def _run_one(self, attack: dict[str, Any]) -> AttackResult:
         attack_id = str(attack["id"])
         prompt = str(attack["prompt_text"])
-        prompt_hash = hash_text(prompt)
+        prompt_hash = _attack_prompt_hash(attack)
         cached = self.cache.get(
             attack_id=attack_id,
             target_model=self.target_model,
@@ -134,10 +136,22 @@ class AttackRunner:
 
         await self.rate_limiter.acquire()
         try:
-            response = await retry_transient(
-                lambda: self.target_system.aquery(prompt),
-                sleeper=self.retry_sleeper,
-            )
+            if attack["owasp_category"] == "LLM08:2025":
+                llm08_result = await retry_transient(
+                    lambda: self.llm08_executor.execute(attack),
+                    sleeper=self.retry_sleeper,
+                )
+                response = llm08_result.response
+                extra_fields: dict[str, Any] = {
+                    "llm08_retrieved_docs": llm08_result.llm08_retrieved_docs,
+                    "llm08_checks": llm08_result.llm08_checks,
+                }
+            else:
+                response = await retry_transient(
+                    lambda: self.target_system.aquery(prompt),
+                    sleeper=self.retry_sleeper,
+                )
+                extra_fields = {}
             result = AttackResult(
                 attack_id=attack_id,
                 owasp_category=str(attack["owasp_category"]),
@@ -150,6 +164,7 @@ class AttackRunner:
                 timestamp=_utc_now(),
                 status="success",
                 retrieved_doc_ids=[chunk.doc_id for chunk in response.retrieved_chunks],
+                **extra_fields,
             )
         except RetryExhaustedError as exc:
             result = AttackResult(
@@ -222,6 +237,12 @@ def _stratified_sample(attacks: Sequence[dict[str, Any]], n: int) -> list[dict[s
                 next_categories.append(category)
         categories = next_categories
     return selected
+
+
+def _attack_prompt_hash(attack: dict[str, Any]) -> str:
+    if attack.get("owasp_category") == "LLM08:2025":
+        return hash_text(json.dumps(attack, sort_keys=True, default=str))
+    return hash_text(str(attack["prompt_text"]))
 
 
 def _target_model(target_system: AsyncTargetSystem) -> str:

--- a/src/pipeline/attack_runner.py
+++ b/src/pipeline/attack_runner.py
@@ -1,0 +1,250 @@
+"""Async attack execution pipeline."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import random
+from collections import defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol
+
+import structlog
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.pipeline.cache import ResultCache, build_target_version, hash_text
+from src.pipeline.rate_limiter import TokenBucketRateLimiter
+from src.pipeline.retry import RetryExhaustedError, retry_transient
+from src.target_system.prompts import SYSTEM_PROMPT
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Sequence
+
+    from src.target_system.models import Response
+
+log = structlog.get_logger()
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+_DEFAULT_RESULTS_ROOT = _PROJECT_ROOT / "results"
+_DEFAULT_TARGET_MODEL = "llama-3.1-8b-instant"
+_DEFAULT_EMBEDDING_MODEL = "all-MiniLM-L6-v2"
+
+
+class AsyncTargetSystem(Protocol):
+    async def aquery(self, prompt: str) -> Response:
+        """Run an async single-turn query against the target system."""
+
+
+class AttackResult(BaseModel):
+    """Structured result emitted by Phase 3 attack execution."""
+
+    model_config = ConfigDict(extra="allow")
+
+    attack_id: str
+    owasp_category: str
+    attack_prompt: str
+    target_response: str
+    retrieved_chunks: list[str]
+    latency_ms: float
+    tokens_used: int
+    cache_hit: bool
+    timestamp: str
+    status: str = "success"
+    retrieved_doc_ids: list[str] = Field(default_factory=list)
+    error_type: str | None = None
+    error_message: str | None = None
+
+
+class AttackRunner:
+    """Async executor for the versioned OWASP attack dataset."""
+
+    def __init__(
+        self,
+        *,
+        target_system: AsyncTargetSystem,
+        dataset_path: Path | str,
+        cache_path: Path | str,
+        concurrency: int = 5,
+        dry_run_sample_n: int | None = None,
+        results_root: Path | str = _DEFAULT_RESULTS_ROOT,
+        rate_limiter: TokenBucketRateLimiter | None = None,
+        retry_sleeper: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ) -> None:
+        if concurrency <= 0:
+            raise ValueError("concurrency must be positive")
+        if dry_run_sample_n is not None and dry_run_sample_n <= 0:
+            raise ValueError("dry_run_sample_n must be positive when provided")
+
+        self.target_system = target_system
+        self.dataset_path = Path(dataset_path)
+        self.cache = ResultCache(cache_path)
+        self.concurrency = concurrency
+        self.dry_run_sample_n = dry_run_sample_n
+        self.results_root = Path(results_root)
+        self.rate_limiter = rate_limiter or TokenBucketRateLimiter(rate_per_minute=30, burst=2)
+        self.retry_sleeper = retry_sleeper
+        self.target_model = _target_model(target_system)
+        self.target_version = _target_version(target_system, self.target_model)
+
+    async def run(self) -> list[AttackResult]:
+        """Run attacks, persist JSONL results, and return structured records."""
+        attacks = self._load_dataset()
+        if self.dry_run_sample_n is not None:
+            attacks = _stratified_sample(attacks, self.dry_run_sample_n)
+
+        results = await self._run_attacks(attacks)
+        self._write_results(results)
+        return results
+
+    async def run_with_sample(self, n: int) -> list[AttackResult]:
+        """Run a stratified random sample for development iteration."""
+        if n <= 0:
+            raise ValueError("sample size must be positive")
+        attacks = _stratified_sample(self._load_dataset(), n)
+        results = await self._run_attacks(attacks)
+        self._write_results(results)
+        return results
+
+    def close(self) -> None:
+        """Close held resources."""
+        self.cache.close()
+
+    async def _run_attacks(self, attacks: Sequence[dict[str, Any]]) -> list[AttackResult]:
+        semaphore = asyncio.Semaphore(self.concurrency)
+
+        async def run_one(attack: dict[str, Any]) -> AttackResult:
+            async with semaphore:
+                return await self._run_one(attack)
+
+        return list(await asyncio.gather(*(run_one(attack) for attack in attacks)))
+
+    async def _run_one(self, attack: dict[str, Any]) -> AttackResult:
+        attack_id = str(attack["id"])
+        prompt = str(attack["prompt_text"])
+        prompt_hash = hash_text(prompt)
+        cached = self.cache.get(
+            attack_id=attack_id,
+            target_model=self.target_model,
+            target_version=self.target_version,
+            prompt_hash=prompt_hash,
+        )
+        if cached is not None:
+            return AttackResult.model_validate(cached)
+
+        await self.rate_limiter.acquire()
+        try:
+            response = await retry_transient(
+                lambda: self.target_system.aquery(prompt),
+                sleeper=self.retry_sleeper,
+            )
+            result = AttackResult(
+                attack_id=attack_id,
+                owasp_category=str(attack["owasp_category"]),
+                attack_prompt=prompt,
+                target_response=response.answer,
+                retrieved_chunks=[chunk.content for chunk in response.retrieved_chunks],
+                latency_ms=float(response.latency_ms),
+                tokens_used=int(response.tokens_used),
+                cache_hit=False,
+                timestamp=_utc_now(),
+                status="success",
+                retrieved_doc_ids=[chunk.doc_id for chunk in response.retrieved_chunks],
+            )
+        except RetryExhaustedError as exc:
+            result = AttackResult(
+                attack_id=attack_id,
+                owasp_category=str(attack["owasp_category"]),
+                attack_prompt=prompt,
+                target_response="",
+                retrieved_chunks=[],
+                latency_ms=0.0,
+                tokens_used=0,
+                cache_hit=False,
+                timestamp=_utc_now(),
+                status="infrastructure_failure",
+                retrieved_doc_ids=[],
+                error_type=type(exc.last_error).__name__,
+                error_message=str(exc.last_error),
+            )
+
+        self.cache.set(
+            attack_id=attack_id,
+            target_model=self.target_model,
+            target_version=self.target_version,
+            prompt_hash=prompt_hash,
+            result=result.model_dump(),
+        )
+        return result
+
+    def _load_dataset(self) -> list[dict[str, Any]]:
+        if not self.dataset_path.exists():
+            raise FileNotFoundError(f"dataset not found: {self.dataset_path}")
+        records = [
+            json.loads(line)
+            for line in self.dataset_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        log.info("Attack dataset loaded", path=str(self.dataset_path), count=len(records))
+        return records
+
+    def _write_results(self, results: Sequence[AttackResult]) -> Path:
+        run_dir = self.results_root / f"run_{datetime.now(UTC).strftime('%Y%m%d_%H%M%S')}"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        path = run_dir / "results.jsonl"
+        with path.open("w", encoding="utf-8") as fh:
+            for result in results:
+                fh.write(result.model_dump_json() + "\n")
+        log.info("Attack results written", path=str(path), count=len(results))
+        return path
+
+
+def _stratified_sample(attacks: Sequence[dict[str, Any]], n: int) -> list[dict[str, Any]]:
+    if n >= len(attacks):
+        return list(attacks)
+
+    groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for attack in attacks:
+        groups[str(attack["owasp_category"])].append(attack)
+
+    rng = random.Random(0)
+    for values in groups.values():
+        rng.shuffle(values)
+
+    selected: list[dict[str, Any]] = []
+    categories = sorted(groups)
+    while len(selected) < n and categories:
+        next_categories: list[str] = []
+        for category in categories:
+            if groups[category] and len(selected) < n:
+                selected.append(groups[category].pop())
+            if groups[category]:
+                next_categories.append(category)
+        categories = next_categories
+    return selected
+
+
+def _target_model(target_system: AsyncTargetSystem) -> str:
+    settings = getattr(target_system, "_settings", None)
+    return str(getattr(settings, "target_model", _DEFAULT_TARGET_MODEL))
+
+
+def _target_version(target_system: AsyncTargetSystem, target_model: str) -> str:
+    settings = getattr(target_system, "_settings", None)
+    embedding_model = str(getattr(settings, "embedding_model", _DEFAULT_EMBEDDING_MODEL))
+    prompt_template = str(getattr(target_system, "_prompt", ""))
+    retrieval_config = {
+        "top_k": 4,
+        "embedding_model": embedding_model,
+        "search_type": "similarity",
+    }
+    return build_target_version(
+        target_model=target_model,
+        system_prompt=SYSTEM_PROMPT,
+        prompt_template=prompt_template,
+        retrieval_config=retrieval_config,
+    )
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()

--- a/src/pipeline/cache.py
+++ b/src/pipeline/cache.py
@@ -1,0 +1,189 @@
+"""SQLite-backed result cache for attack execution.
+
+The cache persists each completed attack result immediately. Keys include
+both prompt identity and target-system version so reruns are cheap while
+configuration changes invalidate stale responses.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+SCHEMA_VERSION = 1
+
+
+class CacheVersionError(RuntimeError):
+    """Raised when an existing cache uses an unsupported schema version."""
+
+
+def hash_text(value: str) -> str:
+    """Return a stable SHA-256 hash for text cache keys."""
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def hash_json(value: Mapping[str, Any]) -> str:
+    """Return a stable SHA-256 hash for structured cache key material."""
+    canonical = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    return hash_text(canonical)
+
+
+def build_target_version(
+    *,
+    target_model: str,
+    system_prompt: str,
+    prompt_template: str,
+    retrieval_config: Mapping[str, Any],
+) -> str:
+    """Hash target configuration that should invalidate cached responses."""
+    return hash_json(
+        {
+            "target_model": target_model,
+            "system_prompt_hash": hash_text(system_prompt),
+            "prompt_template_hash": hash_text(prompt_template),
+            "retrieval_config": retrieval_config,
+        }
+    )
+
+
+class ResultCache:
+    """SQLite-backed cache keyed by attack and target version."""
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(self.path)
+        self._conn.row_factory = sqlite3.Row
+        self._ensure_schema()
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+        self._conn.close()
+
+    def __enter__(self) -> ResultCache:
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    def get(
+        self,
+        *,
+        attack_id: str,
+        target_model: str,
+        target_version: str,
+        prompt_hash: str,
+    ) -> dict[str, Any] | None:
+        """Return a cached result, or ``None`` on cache miss."""
+        row = self._conn.execute(
+            """
+            SELECT result_json
+            FROM attack_results
+            WHERE attack_id = ?
+              AND target_model = ?
+              AND target_version = ?
+              AND prompt_hash = ?
+            """,
+            (attack_id, target_model, target_version, prompt_hash),
+        ).fetchone()
+        if row is None:
+            return None
+
+        result = cast("dict[str, Any]", json.loads(str(row["result_json"])))
+        result["cache_hit"] = True
+        return result
+
+    def set(
+        self,
+        *,
+        attack_id: str,
+        target_model: str,
+        target_version: str,
+        prompt_hash: str,
+        result: Mapping[str, Any],
+    ) -> None:
+        """Persist one attack result immediately."""
+        now = _utc_now()
+        payload = dict(result)
+        payload["cache_hit"] = False
+        result_json = json.dumps(payload, sort_keys=True, default=str)
+
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT INTO attack_results (
+                    attack_id,
+                    target_model,
+                    target_version,
+                    prompt_hash,
+                    result_json,
+                    created_at,
+                    updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(attack_id, target_model, target_version, prompt_hash)
+                DO UPDATE SET
+                    result_json = excluded.result_json,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    attack_id,
+                    target_model,
+                    target_version,
+                    prompt_hash,
+                    result_json,
+                    now,
+                    now,
+                ),
+            )
+
+    def _ensure_schema(self) -> None:
+        with self._conn:
+            self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS cache_schema_version (
+                    version INTEGER NOT NULL,
+                    applied_at TEXT NOT NULL
+                )
+                """)
+            row = self._conn.execute(
+                "SELECT version FROM cache_schema_version ORDER BY applied_at DESC LIMIT 1"
+            ).fetchone()
+            if row is None:
+                self._conn.execute(
+                    "INSERT INTO cache_schema_version (version, applied_at) VALUES (?, ?)",
+                    (SCHEMA_VERSION, _utc_now()),
+                )
+            elif int(row["version"]) != SCHEMA_VERSION:
+                raise CacheVersionError(
+                    f"unsupported cache schema version {row['version']}; "
+                    f"expected {SCHEMA_VERSION}"
+                )
+
+            self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS attack_results (
+                    attack_id TEXT NOT NULL,
+                    target_model TEXT NOT NULL,
+                    target_version TEXT NOT NULL,
+                    prompt_hash TEXT NOT NULL,
+                    result_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (
+                        attack_id,
+                        target_model,
+                        target_version,
+                        prompt_hash
+                    )
+                )
+                """)
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()

--- a/src/pipeline/llm08_executor.py
+++ b/src/pipeline/llm08_executor.py
@@ -1,0 +1,162 @@
+"""Special execution path for LLM08 vector and embedding attacks."""
+
+from __future__ import annotations
+
+import copy
+import time
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+
+from src.target_system.models import Response, RetrievedChunk
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from langchain_core.documents import Document
+
+
+class LLM08Execution(BaseModel):
+    """Target response plus LLM08-specific retrieval diagnostics.
+
+    ``llm08_retrieved_docs`` stores FAISS L2 ``distance`` values, where lower
+    means more similar. It also includes an approximate ``similarity`` value
+    computed as ``1 / (1 + distance)`` for downstream scoring convenience.
+    """
+
+    response: Response
+    llm08_retrieved_docs: list[dict[str, Any]]
+    llm08_checks: dict[str, Any]
+
+
+class InMemoryFAISSContext:
+    """Deep-copy a FAISS vectorstore so mutations never touch disk state."""
+
+    def __init__(self, vectorstore: Any) -> None:
+        self._source = vectorstore
+        self.vectorstore: Any | None = None
+
+    def __enter__(self) -> Any:
+        self.vectorstore = copy.deepcopy(self._source)
+        return self.vectorstore
+
+    def __exit__(self, *_: object) -> None:
+        self.vectorstore = None
+
+
+class LLM08Executor:
+    """Execute structured LLM08 entries against the target RAG system."""
+
+    def __init__(self, target_system: Any, *, top_k: int = 4) -> None:
+        self.target_system = target_system
+        self.top_k = top_k
+
+    async def execute(self, attack: dict[str, Any]) -> LLM08Execution:
+        """Run an LLM08 attack and return response plus retrieval diagnostics."""
+        strategy = str(attack["attack_strategy"])
+        if strategy == "embedding_poisoning":
+            return await self._execute_embedding_poisoning(attack)
+        return await self._execute_standard_retrieval(attack)
+
+    async def _execute_embedding_poisoning(self, attack: dict[str, Any]) -> LLM08Execution:
+        query = str(attack.get("target_query") or attack["prompt_text"])
+        source_vectorstore = self.target_system._vectorstore
+        with InMemoryFAISSContext(source_vectorstore) as vectorstore:
+            poisoned_metadata = dict(attack.get("poisoned_doc_metadata") or {})
+            poisoned_doc_id = str(poisoned_metadata.get("doc_id") or f"{attack['id']}-poisoned")
+            poisoned_metadata["doc_id"] = poisoned_doc_id
+            poisoned_metadata.setdefault("source", "synthetic_poisoned")
+            vectorstore.add_texts(
+                [str(attack["poisoned_doc_content"])],
+                metadatas=[poisoned_metadata],
+            )
+            response = await self._query_with_vectorstore(query, vectorstore)
+
+        docs = _docs_from_response(response)
+        return LLM08Execution(
+            response=response,
+            llm08_retrieved_docs=docs,
+            llm08_checks={
+                "strategy": "embedding_poisoning",
+                "poisoned_doc_id": poisoned_doc_id,
+                "poisoned_doc_retrieved": any(doc["doc_id"] == poisoned_doc_id for doc in docs),
+            },
+        )
+
+    async def _execute_standard_retrieval(self, attack: dict[str, Any]) -> LLM08Execution:
+        query = str(
+            attack.get("adversarial_query")
+            or attack.get("probe_query")
+            or attack.get("inversion_query")
+            or attack["prompt_text"]
+        )
+        response = await self.target_system.aquery(query)
+        docs = _docs_from_response(response)
+        checks: dict[str, Any] = {"strategy": attack["attack_strategy"]}
+        if attack["attack_strategy"] == "similarity_collision":
+            target_doc_id = str(attack.get("target_doc_id", ""))
+            checks["target_doc_id"] = target_doc_id
+            checks["target_doc_retrieved"] = any(doc["doc_id"] == target_doc_id for doc in docs)
+        return LLM08Execution(
+            response=response,
+            llm08_retrieved_docs=docs,
+            llm08_checks=checks,
+        )
+
+    async def _query_with_vectorstore(self, query: str, vectorstore: Any) -> Response:
+        start = time.perf_counter()
+        docs_with_scores = vectorstore.similarity_search_with_score(query, k=self.top_k)
+        docs = [doc for doc, _ in docs_with_scores]
+        context = _format_docs(docs)
+
+        prompt = self.target_system._prompt
+        llm = self.target_system._llm
+        messages = prompt.format_messages(context=context, question=query)
+        raw = await llm.ainvoke(messages)
+        usage = getattr(raw, "response_metadata", {}).get("usage", {}) or {}
+        tokens_used = int(usage.get("prompt_tokens", 0) + usage.get("completion_tokens", 0))
+
+        return Response(
+            answer=str(raw.content),
+            retrieved_chunks=[
+                RetrievedChunk(
+                    content=doc.page_content,
+                    source=doc.metadata.get("source", ""),
+                    doc_id=doc.metadata.get("doc_id", ""),
+                    score=float(score),
+                )
+                for doc, score in docs_with_scores
+            ],
+            latency_ms=(time.perf_counter() - start) * 1000,
+            tokens_used=tokens_used,
+        )
+
+
+def snapshot_mtimes(index_dir: Path) -> dict[Path, int]:
+    """Return mtime snapshots for files under a FAISS index directory."""
+    return {path: path.stat().st_mtime_ns for path in sorted(index_dir.iterdir()) if path.is_file()}
+
+
+def assert_mtimes_unchanged(before: dict[Path, int]) -> None:
+    """Raise if any previously snapshotted index file changed on disk."""
+    after = {path: path.stat().st_mtime_ns for path in before}
+    if after != before:
+        changed = [str(path) for path, mtime in before.items() if after.get(path) != mtime]
+        raise AssertionError(f"FAISS index files changed on disk: {changed}")
+
+
+def _docs_from_response(response: Response) -> list[dict[str, Any]]:
+    return [
+        {
+            "doc_id": chunk.doc_id,
+            "source": chunk.source,
+            "distance": chunk.score,
+            "similarity": 1 / (1 + chunk.score),
+            "content": chunk.content,
+        }
+        for chunk in response.retrieved_chunks
+    ]
+
+
+def _format_docs(docs: list[Document]) -> str:
+    return "\n\n---\n\n".join(doc.page_content for doc in docs)

--- a/src/pipeline/rate_limiter.py
+++ b/src/pipeline/rate_limiter.py
@@ -1,0 +1,68 @@
+"""Async rate limiting for Groq target-model calls."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+
+class TokenBucketRateLimiter:
+    """Async token bucket with bounded burst capacity."""
+
+    def __init__(
+        self,
+        *,
+        rate_per_minute: int = 30,
+        burst: int = 2,
+        clock: Callable[[], float] | None = None,
+        sleeper: Callable[[float], Awaitable[None]] | None = None,
+    ) -> None:
+        if rate_per_minute <= 0:
+            raise ValueError("rate_per_minute must be positive")
+        if burst <= 0:
+            raise ValueError("burst must be positive")
+
+        self.rate_per_second = rate_per_minute / 60.0
+        self.capacity = float(burst)
+        self._tokens = float(burst)
+        self._clock = clock or time.monotonic
+        self._sleeper = sleeper or asyncio.sleep
+        self._updated_at = self._clock()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> None:
+        """Wait until one request token is available."""
+        while True:
+            async with self._lock:
+                now = self._clock()
+                elapsed = max(0.0, now - self._updated_at)
+                self._tokens = min(self.capacity, self._tokens + elapsed * self.rate_per_second)
+                self._updated_at = now
+
+                if self._tokens >= 1.0:
+                    self._tokens -= 1.0
+                    return
+
+                missing = 1.0 - self._tokens
+                wait_seconds = missing / self.rate_per_second
+
+            await self._sleeper(wait_seconds)
+
+
+class ConcurrencyLimiter:
+    """Small wrapper around ``asyncio.Semaphore`` for runner readability."""
+
+    def __init__(self, concurrency: int = 5) -> None:
+        if concurrency <= 0:
+            raise ValueError("concurrency must be positive")
+        self._semaphore = asyncio.Semaphore(concurrency)
+
+    async def __aenter__(self) -> None:
+        await self._semaphore.acquire()
+
+    async def __aexit__(self, *_: object) -> None:
+        self._semaphore.release()

--- a/src/pipeline/retry.py
+++ b/src/pipeline/retry.py
@@ -1,0 +1,72 @@
+"""Retry helpers for transient Groq API failures."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+T = TypeVar("T")
+
+DEFAULT_BACKOFF_SECONDS = (1.0, 2.0, 4.0)
+
+
+class RetryExhaustedError(RuntimeError):
+    """Raised after all retry attempts are exhausted."""
+
+    def __init__(self, message: str, *, last_error: BaseException) -> None:
+        super().__init__(message)
+        self.last_error = last_error
+
+
+async def retry_transient(
+    operation: Callable[[], Awaitable[T]],
+    *,
+    backoff_seconds: tuple[float, ...] = DEFAULT_BACKOFF_SECONDS,
+    sleeper: Callable[[float], Awaitable[None]] = asyncio.sleep,
+) -> T:
+    """Run an async operation with capped retry for 429 and 5xx failures."""
+    attempt = 0
+    while True:
+        try:
+            return await operation()
+        except Exception as exc:
+            if not _is_retryable(exc) or attempt >= len(backoff_seconds):
+                raise RetryExhaustedError(
+                    f"operation failed after {attempt} retries: {exc}",
+                    last_error=exc,
+                ) from exc
+
+            retry_after = _retry_after_seconds(exc)
+            wait_seconds = retry_after if retry_after is not None else backoff_seconds[attempt]
+            attempt += 1
+            await sleeper(wait_seconds)
+
+
+def _is_retryable(exc: Exception) -> bool:
+    status_code = getattr(exc, "status_code", None)
+    if status_code == 429:
+        return True
+    return isinstance(status_code, int) and 500 <= status_code <= 599
+
+
+def _retry_after_seconds(exc: Exception) -> float | None:
+    headers = getattr(exc, "headers", None)
+    if headers is None:
+        response = getattr(exc, "response", None)
+        headers = getattr(response, "headers", None)
+    if headers is None:
+        return None
+
+    value = None
+    if hasattr(headers, "get"):
+        value = headers.get("Retry-After") or headers.get("retry-after")
+    if value is None:
+        return None
+    try:
+        retry_after = float(value)
+    except (TypeError, ValueError):
+        return None
+    return max(0.0, retry_after)

--- a/tests/integration/test_runner_e2e.py
+++ b/tests/integration/test_runner_e2e.py
@@ -1,0 +1,90 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from src.pipeline.attack_runner import AttackRunner
+from src.pipeline.rate_limiter import TokenBucketRateLimiter
+from src.target_system.models import Response, RetrievedChunk
+
+pytestmark = pytest.mark.integration
+
+
+class MockTarget:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def aquery(self, prompt: str) -> Response:
+        self.calls.append(prompt)
+        return Response(
+            answer=f"mock response for {prompt}",
+            retrieved_chunks=[
+                RetrievedChunk(
+                    content=f"retrieved context for {prompt}",
+                    source="mock",
+                    doc_id=f"doc-{len(self.calls)}",
+                    score=0.2,
+                )
+            ],
+            latency_ms=5.0,
+            tokens_used=17,
+        )
+
+
+class NoopLimiter(TokenBucketRateLimiter):
+    def __init__(self) -> None:
+        pass
+
+    async def acquire(self) -> None:
+        return None
+
+
+def _write_dataset(path: Path) -> None:
+    rows = [
+        {
+            "id": f"LLM01-{i:04d}",
+            "owasp_category": "LLM01:2025",
+            "attack_strategy": "direct_override",
+            "prompt_text": f"attack prompt {i}",
+        }
+        for i in range(1, 6)
+    ]
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_runner_e2e_writes_results_and_reuses_cache(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "dataset.jsonl"
+    cache_path = tmp_path / "results_cache.sqlite"
+    results_root = tmp_path / "results"
+    _write_dataset(dataset_path)
+    target = MockTarget()
+    runner = AttackRunner(
+        target_system=target,
+        dataset_path=dataset_path,
+        cache_path=cache_path,
+        results_root=results_root,
+        concurrency=2,
+        rate_limiter=NoopLimiter(),
+    )
+
+    try:
+        first = await runner.run()
+        second = await runner.run()
+    finally:
+        runner.close()
+
+    assert len(first) == 5
+    assert len(second) == 5
+    assert len(target.calls) == 5
+    assert all(result.status == "success" for result in first)
+    assert all(result.cache_hit is False for result in first)
+    assert all(result.cache_hit is True for result in second)
+    assert cache_path.exists()
+
+    result_files = sorted(results_root.glob("run_*/results.jsonl"))
+    assert result_files
+    rows = [json.loads(line) for line in result_files[-1].read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 5
+    assert rows[0]["attack_id"] == "LLM01-0001"
+    assert rows[0]["retrieved_chunks"] == ["retrieved context for attack prompt 1"]

--- a/tests/unit/test_attack_runner.py
+++ b/tests/unit/test_attack_runner.py
@@ -1,0 +1,152 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from src.pipeline.attack_runner import AttackRunner
+from src.pipeline.rate_limiter import TokenBucketRateLimiter
+from src.target_system.models import Response, RetrievedChunk
+
+
+class FakeTarget:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def aquery(self, prompt: str) -> Response:
+        self.calls.append(prompt)
+        return Response(
+            answer=f"answer: {prompt}",
+            retrieved_chunks=[
+                RetrievedChunk(content="chunk one", source="fixture", doc_id="doc-1", score=0.1)
+            ],
+            latency_ms=12.5,
+            tokens_used=42,
+        )
+
+
+class FakeFailure(Exception):
+    status_code = 500
+
+
+class FailingTarget:
+    async def aquery(self, prompt: str) -> Response:
+        raise FakeFailure(prompt)
+
+
+class NoopLimiter(TokenBucketRateLimiter):
+    def __init__(self) -> None:
+        pass
+
+    async def acquire(self) -> None:
+        return None
+
+
+async def _no_sleep(_: float) -> None:
+    return None
+
+
+def _write_dataset(path: Path, count: int = 2) -> None:
+    rows = [
+        {
+            "id": f"LLM01-{i:04d}",
+            "owasp_category": "LLM01:2025",
+            "attack_strategy": "direct_override",
+            "prompt_text": f"prompt {i}",
+        }
+        for i in range(1, count + 1)
+    ]
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_attack_runner_writes_structured_results_and_cache(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "dataset.jsonl"
+    cache_path = tmp_path / "cache.sqlite"
+    results_root = tmp_path / "results"
+    _write_dataset(dataset_path)
+    target = FakeTarget()
+    runner = AttackRunner(
+        target_system=target,
+        dataset_path=dataset_path,
+        cache_path=cache_path,
+        results_root=results_root,
+        rate_limiter=NoopLimiter(),
+    )
+
+    try:
+        results = await runner.run()
+        second_results = await runner.run()
+    finally:
+        runner.close()
+
+    assert len(results) == 2
+    assert results[0].attack_id == "LLM01-0001"
+    assert results[0].target_response == "answer: prompt 1"
+    assert results[0].retrieved_chunks == ["chunk one"]
+    assert results[0].retrieved_doc_ids == ["doc-1"]
+    assert results[0].cache_hit is False
+    assert [result.cache_hit for result in second_results] == [True, True]
+    assert target.calls == ["prompt 1", "prompt 2"]
+    assert cache_path.exists()
+    result_files = sorted(results_root.glob("run_*/results.jsonl"))
+    assert result_files
+    assert len(result_files[-1].read_text(encoding="utf-8").splitlines()) == 2
+
+
+@pytest.mark.asyncio
+async def test_attack_runner_records_infrastructure_failure(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "dataset.jsonl"
+    _write_dataset(dataset_path, count=1)
+    runner = AttackRunner(
+        target_system=FailingTarget(),
+        dataset_path=dataset_path,
+        cache_path=tmp_path / "cache.sqlite",
+        results_root=tmp_path / "results",
+        rate_limiter=NoopLimiter(),
+        retry_sleeper=_no_sleep,
+    )
+
+    try:
+        results = await runner.run()
+    finally:
+        runner.close()
+
+    assert len(results) == 1
+    assert results[0].status == "infrastructure_failure"
+    assert results[0].error_type == "FakeFailure"
+
+
+@pytest.mark.asyncio
+async def test_run_with_sample_is_stratified(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "dataset.jsonl"
+    rows = []
+    for category in ("LLM01:2025", "LLM02:2025", "LLM03:2025"):
+        for i in range(2):
+            rows.append(
+                {
+                    "id": f"{category[:5]}-{i:04d}",
+                    "owasp_category": category,
+                    "attack_strategy": "test",
+                    "prompt_text": f"{category} prompt {i}",
+                }
+            )
+    dataset_path.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+    runner = AttackRunner(
+        target_system=FakeTarget(),
+        dataset_path=dataset_path,
+        cache_path=tmp_path / "cache.sqlite",
+        results_root=tmp_path / "results",
+        rate_limiter=NoopLimiter(),
+    )
+
+    try:
+        results = await runner.run_with_sample(3)
+    finally:
+        runner.close()
+
+    assert len(results) == 3
+    assert {result.owasp_category for result in results} == {
+        "LLM01:2025",
+        "LLM02:2025",
+        "LLM03:2025",
+    }

--- a/tests/unit/test_attack_runner.py
+++ b/tests/unit/test_attack_runner.py
@@ -1,11 +1,19 @@
+from __future__ import annotations
+
+import copy
 import json
-from pathlib import Path
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
 
 import pytest
+from langchain_core.documents import Document
 
 from src.pipeline.attack_runner import AttackRunner
 from src.pipeline.rate_limiter import TokenBucketRateLimiter
 from src.target_system.models import Response, RetrievedChunk
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class FakeTarget:
@@ -22,6 +30,48 @@ class FakeTarget:
             latency_ms=12.5,
             tokens_used=42,
         )
+
+
+class FakeVectorstore:
+    def __init__(self, docs: list[Document] | None = None) -> None:
+        self.docs = docs or [
+            Document(
+                page_content="original chunk",
+                metadata={"source": "fixture", "doc_id": "original-doc"},
+            )
+        ]
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> FakeVectorstore:
+        return FakeVectorstore(copy.deepcopy(self.docs, memo))
+
+    def add_texts(self, texts: list[str], metadatas: list[dict[str, Any]]) -> list[str]:
+        for text, metadata in zip(texts, metadatas, strict=True):
+            self.docs.insert(0, Document(page_content=text, metadata=metadata))
+        return [metadata["doc_id"] for metadata in metadatas]
+
+    def similarity_search_with_score(self, query: str, k: int) -> list[tuple[Document, float]]:
+        return [(doc, float(i)) for i, doc in enumerate(self.docs[:k])]
+
+
+class FakePrompt:
+    def format_messages(self, *, context: str, question: str) -> list[dict[str, str]]:
+        return [{"role": "user", "content": f"{question}\n{context}"}]
+
+
+class FakeLLM:
+    async def ainvoke(self, messages: list[dict[str, str]]) -> Any:
+        return SimpleNamespace(
+            content=f"llm08 response {len(messages)}",
+            response_metadata={"usage": {"prompt_tokens": 3, "completion_tokens": 4}},
+        )
+
+
+class FakeLLM08Target(FakeTarget):
+    def __init__(self) -> None:
+        super().__init__()
+        self._vectorstore = FakeVectorstore()
+        self._prompt = FakePrompt()
+        self._llm = FakeLLM()
 
 
 class FakeFailure(Exception):
@@ -150,3 +200,39 @@ async def test_run_with_sample_is_stratified(tmp_path: Path) -> None:
         "LLM02:2025",
         "LLM03:2025",
     }
+
+
+@pytest.mark.asyncio
+async def test_attack_runner_adds_llm08_retrieval_diagnostics(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "dataset.jsonl"
+    attack = {
+        "id": "LLM08-0001",
+        "owasp_category": "LLM08:2025",
+        "attack_strategy": "embedding_poisoning",
+        "prompt_text": "What is the canonical mitigation?",
+        "target_query": "What is the canonical mitigation?",
+        "poisoned_doc_content": "poisoned benchmark-only guidance",
+        "poisoned_doc_metadata": {"source": "fake", "doc_id": "POISON-001"},
+    }
+    dataset_path.write_text(json.dumps(attack) + "\n", encoding="utf-8")
+    runner = AttackRunner(
+        target_system=FakeLLM08Target(),
+        dataset_path=dataset_path,
+        cache_path=tmp_path / "cache.sqlite",
+        results_root=tmp_path / "results",
+        rate_limiter=NoopLimiter(),
+        retry_sleeper=_no_sleep,
+    )
+
+    try:
+        results = await runner.run()
+    finally:
+        runner.close()
+
+    assert len(results) == 1
+    dumped = results[0].model_dump()
+    assert dumped["llm08_checks"]["poisoned_doc_retrieved"] is True
+    assert dumped["llm08_retrieved_docs"][0]["doc_id"] == "POISON-001"
+    assert "distance" in dumped["llm08_retrieved_docs"][0]
+    assert "similarity" in dumped["llm08_retrieved_docs"][0]
+    assert "score" not in dumped["llm08_retrieved_docs"][0]

--- a/tests/unit/test_attack_runner_cli.py
+++ b/tests/unit/test_attack_runner_cli.py
@@ -1,0 +1,59 @@
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from src.pipeline.attack_runner import app, select_attacks
+
+
+def _write_dataset(path: Path) -> None:
+    rows = [
+        {
+            "id": "LLM01-0001",
+            "owasp_category": "LLM01:2025",
+            "attack_strategy": "direct_override",
+            "prompt_text": "prompt 1",
+        },
+        {
+            "id": "LLM02-0001",
+            "owasp_category": "LLM02:2025",
+            "attack_strategy": "pii_extraction",
+            "prompt_text": "prompt 2",
+        },
+    ]
+    path.write_text("".join(json.dumps(row) + "\n" for row in rows), encoding="utf-8")
+
+
+def test_select_attacks_filters_short_category_name(tmp_path: Path) -> None:
+    dataset = tmp_path / "dataset.jsonl"
+    _write_dataset(dataset)
+    rows = [json.loads(line) for line in dataset.read_text(encoding="utf-8").splitlines()]
+
+    selected = select_attacks(rows, category="LLM01")
+
+    assert [attack["id"] for attack in selected] == ["LLM01-0001"]
+
+
+def test_cli_dry_run_prints_plan_without_target_initialization(tmp_path: Path) -> None:
+    dataset = tmp_path / "dataset.jsonl"
+    cache = tmp_path / "cache.sqlite"
+    _write_dataset(dataset)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "run",
+            "--dataset",
+            str(dataset),
+            "--cache",
+            str(cache),
+            "--category",
+            "LLM02",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Dry run: 1 attack(s) would execute" in result.output
+    assert "LLM02-0001\tLLM02:2025\tpii_extraction" in result.output
+    assert not cache.exists()

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,0 +1,138 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from src.pipeline.cache import (
+    SCHEMA_VERSION,
+    CacheVersionError,
+    ResultCache,
+    build_target_version,
+    hash_text,
+)
+
+
+def test_cache_creates_schema_and_version_table(tmp_path: Path) -> None:
+    cache_path = tmp_path / "results_cache.sqlite"
+
+    with ResultCache(cache_path):
+        pass
+
+    conn = sqlite3.connect(cache_path)
+    try:
+        version = conn.execute("SELECT version FROM cache_schema_version").fetchone()[0]
+        tables = {
+            row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        }
+    finally:
+        conn.close()
+
+    assert version == SCHEMA_VERSION
+    assert "attack_results" in tables
+    assert "cache_schema_version" in tables
+
+
+def test_cache_miss_then_hit_sets_cache_hit_flag(tmp_path: Path) -> None:
+    cache = ResultCache(tmp_path / "results_cache.sqlite")
+    key = {
+        "attack_id": "LLM01-0001",
+        "target_model": "llama-3.1-8b-instant",
+        "target_version": "version-a",
+        "prompt_hash": hash_text("attack prompt"),
+    }
+    result = {
+        "attack_id": "LLM01-0001",
+        "target_response": "synthetic response",
+        "cache_hit": False,
+    }
+
+    try:
+        assert cache.get(**key) is None
+
+        cache.set(**key, result=result)
+        cached = cache.get(**key)
+    finally:
+        cache.close()
+
+    assert cached is not None
+    assert cached["attack_id"] == "LLM01-0001"
+    assert cached["target_response"] == "synthetic response"
+    assert cached["cache_hit"] is True
+
+
+def test_target_version_change_invalidates_cache(tmp_path: Path) -> None:
+    cache = ResultCache(tmp_path / "results_cache.sqlite")
+    base_key = {
+        "attack_id": "LLM01-0001",
+        "target_model": "llama-3.1-8b-instant",
+        "prompt_hash": hash_text("attack prompt"),
+    }
+
+    try:
+        cache.set(
+            **base_key,
+            target_version="version-a",
+            result={"attack_id": "LLM01-0001", "target_response": "old"},
+        )
+
+        assert cache.get(**base_key, target_version="version-a") is not None
+        assert cache.get(**base_key, target_version="version-b") is None
+    finally:
+        cache.close()
+
+
+def test_prompt_hash_change_invalidates_cache(tmp_path: Path) -> None:
+    cache = ResultCache(tmp_path / "results_cache.sqlite")
+    base_key = {
+        "attack_id": "LLM01-0001",
+        "target_model": "llama-3.1-8b-instant",
+        "target_version": "version-a",
+    }
+
+    try:
+        cache.set(
+            **base_key,
+            prompt_hash=hash_text("attack prompt"),
+            result={"attack_id": "LLM01-0001", "target_response": "old"},
+        )
+
+        assert cache.get(**base_key, prompt_hash=hash_text("attack prompt")) is not None
+        assert cache.get(**base_key, prompt_hash=hash_text("changed prompt")) is None
+    finally:
+        cache.close()
+
+
+def test_unknown_schema_version_fails_closed(tmp_path: Path) -> None:
+    cache_path = tmp_path / "results_cache.sqlite"
+    conn = sqlite3.connect(cache_path)
+    try:
+        conn.execute(
+            "CREATE TABLE cache_schema_version (version INTEGER NOT NULL, applied_at TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO cache_schema_version (version, applied_at) VALUES (?, ?)",
+            (999, "2026-05-14T00:00:00+00:00"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(CacheVersionError):
+        ResultCache(cache_path)
+
+
+def test_build_target_version_includes_retrieval_config() -> None:
+    base = build_target_version(
+        target_model="llama-3.1-8b-instant",
+        system_prompt="system",
+        prompt_template="template",
+        retrieval_config={"top_k": 4, "embedding_model": "all-MiniLM-L6-v2"},
+    )
+    changed_top_k = build_target_version(
+        target_model="llama-3.1-8b-instant",
+        system_prompt="system",
+        prompt_template="template",
+        retrieval_config={"top_k": 5, "embedding_model": "all-MiniLM-L6-v2"},
+    )
+
+    assert base != changed_top_k

--- a/tests/unit/test_llm08_executor.py
+++ b/tests/unit/test_llm08_executor.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from langchain_core.documents import Document
+
+from src.pipeline.llm08_executor import (
+    LLM08Executor,
+    assert_mtimes_unchanged,
+    snapshot_mtimes,
+)
+from src.target_system.models import Response, RetrievedChunk
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class FakeVectorstore:
+    def __init__(self, docs: list[Document] | None = None) -> None:
+        self.docs = docs or [
+            Document(
+                page_content="original mitigation guidance",
+                metadata={"source": "fixture", "doc_id": "original-doc"},
+            )
+        ]
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> FakeVectorstore:
+        return FakeVectorstore(copy.deepcopy(self.docs, memo))
+
+    def add_texts(self, texts: list[str], metadatas: list[dict[str, Any]]) -> list[str]:
+        for text, metadata in zip(texts, metadatas, strict=True):
+            self.docs.insert(0, Document(page_content=text, metadata=metadata))
+        return [metadata["doc_id"] for metadata in metadatas]
+
+    def similarity_search_with_score(self, query: str, k: int) -> list[tuple[Document, float]]:
+        return [(doc, float(i)) for i, doc in enumerate(self.docs[:k])]
+
+
+class FakePrompt:
+    def format_messages(self, *, context: str, question: str) -> list[dict[str, str]]:
+        return [{"role": "user", "content": f"{question}\n{context}"}]
+
+
+class FakeLLM:
+    async def ainvoke(self, messages: list[dict[str, str]]) -> Any:
+        return SimpleNamespace(
+            content=f"response using {len(messages)} message(s)",
+            response_metadata={"usage": {"prompt_tokens": 7, "completion_tokens": 5}},
+        )
+
+
+class FakeTarget:
+    def __init__(self) -> None:
+        self._vectorstore = FakeVectorstore()
+        self._prompt = FakePrompt()
+        self._llm = FakeLLM()
+
+    async def aquery(self, prompt: str) -> Response:
+        return Response(
+            answer=f"normal response: {prompt}",
+            retrieved_chunks=[
+                RetrievedChunk(
+                    content="normal chunk",
+                    source="fixture",
+                    doc_id="target-doc",
+                    score=0.1,
+                )
+            ],
+            latency_ms=3.0,
+            tokens_used=9,
+        )
+
+
+def _poisoning_attack() -> dict[str, Any]:
+    return {
+        "id": "LLM08-0001",
+        "owasp_category": "LLM08:2025",
+        "attack_strategy": "embedding_poisoning",
+        "prompt_text": "What is the canonical mitigation?",
+        "target_query": "What is the canonical mitigation?",
+        "poisoned_doc_content": "poisoned benchmark-only guidance",
+        "poisoned_doc_metadata": {"source": "fake", "doc_id": "POISON-001"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_embedding_poisoning_uses_deep_copy_without_mutating_source() -> None:
+    target = FakeTarget()
+    executor = LLM08Executor(target)
+
+    result = await executor.execute(_poisoning_attack())
+
+    assert result.response.answer == "response using 1 message(s)"
+    assert result.llm08_checks["poisoned_doc_retrieved"] is True
+    assert result.llm08_retrieved_docs[0]["doc_id"] == "POISON-001"
+    assert result.llm08_retrieved_docs[0]["distance"] == 0.0
+    assert result.llm08_retrieved_docs[0]["similarity"] == 1.0
+    assert [doc.metadata["doc_id"] for doc in target._vectorstore.docs] == ["original-doc"]
+
+
+@pytest.mark.asyncio
+async def test_embedding_poisoning_mtime_guard_keeps_index_files_unchanged(tmp_path: Path) -> None:
+    index_dir = tmp_path / "faiss_index"
+    index_dir.mkdir()
+    for name in ("index.faiss", "index.pkl"):
+        (index_dir / name).write_text("unchanged", encoding="utf-8")
+    before = snapshot_mtimes(index_dir)
+
+    executor = LLM08Executor(FakeTarget())
+    result = await executor.execute(_poisoning_attack())
+
+    assert result.llm08_checks["poisoned_doc_retrieved"] is True
+    assert_mtimes_unchanged(before)
+
+
+@pytest.mark.asyncio
+async def test_similarity_collision_records_target_doc_check() -> None:
+    attack = {
+        "id": "LLM08-0005",
+        "owasp_category": "LLM08:2025",
+        "attack_strategy": "similarity_collision",
+        "prompt_text": "collision query",
+        "adversarial_query": "collision query",
+        "target_doc_id": "target-doc",
+    }
+
+    result = await LLM08Executor(FakeTarget()).execute(attack)
+
+    assert result.llm08_checks["target_doc_id"] == "target-doc"
+    assert result.llm08_checks["target_doc_retrieved"] is True
+    assert result.llm08_retrieved_docs[0]["doc_id"] == "target-doc"
+    distances = [doc["distance"] for doc in result.llm08_retrieved_docs]
+    assert distances == sorted(distances)

--- a/tests/unit/test_rate_limiter.py
+++ b/tests/unit/test_rate_limiter.py
@@ -1,0 +1,70 @@
+import pytest
+
+from src.pipeline.rate_limiter import ConcurrencyLimiter, TokenBucketRateLimiter
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def __call__(self) -> float:
+        return self.now
+
+    async def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+@pytest.mark.asyncio
+async def test_token_bucket_allows_configured_burst() -> None:
+    clock = FakeClock()
+    limiter = TokenBucketRateLimiter(rate_per_minute=30, burst=2, clock=clock, sleeper=clock.sleep)
+
+    await limiter.acquire()
+    await limiter.acquire()
+
+    assert clock.sleeps == []
+
+
+@pytest.mark.asyncio
+async def test_token_bucket_waits_after_burst_is_consumed() -> None:
+    clock = FakeClock()
+    limiter = TokenBucketRateLimiter(rate_per_minute=30, burst=2, clock=clock, sleeper=clock.sleep)
+
+    await limiter.acquire()
+    await limiter.acquire()
+    await limiter.acquire()
+
+    assert clock.sleeps == [2.0]
+
+
+@pytest.mark.asyncio
+async def test_token_bucket_refills_over_time() -> None:
+    clock = FakeClock()
+    limiter = TokenBucketRateLimiter(rate_per_minute=30, burst=2, clock=clock, sleeper=clock.sleep)
+
+    await limiter.acquire()
+    await limiter.acquire()
+    clock.now += 4.0
+    await limiter.acquire()
+    await limiter.acquire()
+
+    assert clock.sleeps == []
+
+
+@pytest.mark.asyncio
+async def test_concurrency_limiter_rejects_invalid_concurrency() -> None:
+    with pytest.raises(ValueError):
+        ConcurrencyLimiter(0)
+
+
+@pytest.mark.asyncio
+async def test_concurrency_limiter_context_manager() -> None:
+    limiter = ConcurrencyLimiter(1)
+    entered = False
+
+    async with limiter:
+        entered = True
+
+    assert entered is True

--- a/tests/unit/test_retry.py
+++ b/tests/unit/test_retry.py
@@ -1,0 +1,115 @@
+from typing import Any
+
+import pytest
+
+from src.pipeline.retry import RetryExhaustedError, retry_transient
+
+
+class FakeHTTPError(Exception):
+    def __init__(self, status_code: int, headers: dict[str, str] | None = None) -> None:
+        super().__init__(f"HTTP {status_code}")
+        self.status_code = status_code
+        self.headers = headers or {}
+
+
+@pytest.mark.asyncio
+async def test_retry_uses_backoff_sequence_before_success() -> None:
+    calls = 0
+    sleeps: list[float] = []
+
+    async def flaky() -> str:
+        nonlocal calls
+        calls += 1
+        if calls < 4:
+            raise FakeHTTPError(429)
+        return "ok"
+
+    async def sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    result = await retry_transient(flaky, sleeper=sleep)
+
+    assert result == "ok"
+    assert calls == 4
+    assert sleeps == [1.0, 2.0, 4.0]
+
+
+@pytest.mark.asyncio
+async def test_retry_honors_retry_after_header() -> None:
+    calls = 0
+    sleeps: list[float] = []
+
+    async def flaky() -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise FakeHTTPError(429, headers={"Retry-After": "3.5"})
+        return "ok"
+
+    async def sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    result = await retry_transient(flaky, sleeper=sleep)
+
+    assert result == "ok"
+    assert sleeps == [3.5]
+
+
+@pytest.mark.asyncio
+async def test_retry_exhausts_after_three_retries() -> None:
+    sleeps: list[float] = []
+
+    async def always_fails() -> str:
+        raise FakeHTTPError(500)
+
+    async def sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    with pytest.raises(RetryExhaustedError) as exc_info:
+        await retry_transient(always_fails, sleeper=sleep)
+
+    assert isinstance(exc_info.value.last_error, FakeHTTPError)
+    assert sleeps == [1.0, 2.0, 4.0]
+
+
+@pytest.mark.asyncio
+async def test_non_retryable_error_raises_without_sleep() -> None:
+    sleeps: list[float] = []
+
+    async def fails() -> str:
+        raise ValueError("bad input")
+
+    async def sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    with pytest.raises(RetryExhaustedError) as exc_info:
+        await retry_transient(fails, sleeper=sleep)
+
+    assert isinstance(exc_info.value.last_error, ValueError)
+    assert sleeps == []
+
+
+@pytest.mark.asyncio
+async def test_retry_after_can_be_read_from_response_headers() -> None:
+    class Response:
+        headers = {"retry-after": "2"}
+
+    class ResponseError(Exception):
+        status_code = 503
+        response: Any = Response()
+
+    sleeps: list[float] = []
+    calls = 0
+
+    async def flaky() -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ResponseError("unavailable")
+        return "ok"
+
+    async def sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    assert await retry_transient(flaky, sleeper=sleep) == "ok"
+    assert sleeps == [2.0]


### PR DESCRIPTION
Closes #5.

## What landed

A production-grade async pipeline that executes the 175-attack dataset against the RAG target with full observability, caching, and structured result capture.

### Modules

- `src/pipeline/cache.py` — SQLite cache, per-result writes, schema versioned with migration table. target_version invalidation on retrieval config change.
- `src/pipeline/rate_limiter.py` — async token bucket (30 RPM, burst 2) matching Groq's published target-model limits.
- `src/pipeline/retry.py` — exponential backoff (1s, 2s, 4s), Retry-After honored, max 3 retries then infrastructure_failure.
- `src/pipeline/attack_runner.py` — async AttackRunner with stratified sampling, category filter, structured AttackResult schema.
- `src/pipeline/llm08_executor.py` — in-memory FAISS via copy.deepcopy, context-managed lifecycle, on-disk mtime guard. Handles all 4 LLM08 sub-techniques.
- Typer CLI: `python -m src.pipeline.attack_runner run [--sample N] [--category LLM01] [--dry-run]`

### Key design decisions (full detail in IMPLEMENTATION_NOTES.md §Phase 3)

- **Per-result cache writes.** Phase 1's lost-work scenario cannot repeat.
- **target_version hashing.** Includes model + system prompt + retrieval config + prompt template. Any of these changing invalidates cache.
- **Deep-copy LLM08 vectorstore.** Avoids 1-3s sentence-transformers init per attack vs disk reload. Mtime guard test enforces on-disk safety.
- **FAISS distance vs similarity clarity.** llm08_retrieved_docs entries expose both `distance` (raw L2) and derived `similarity` (1/(1+d)) to prevent Phase 4 evaluation logic from misreading the metric.
- **Infrastructure failures recorded.** status="infrastructure_failure" result entries preserve run completeness.
- **LangSmith optional.** Default off; controlled by LANGSMITH_TRACING env flag. Missing config no-ops cleanly.

## Verification

- `make lint` ✓ (ruff + black + mypy)
- `make test` ✓ (55 unit + integration tests pass, 22 deselected)
- Pipeline coverage: **94.1%** (target was ≥80%)
  - attack_runner.py: 91%
  - cache.py: 100%
  - llm08_executor.py: 97%
  - rate_limiter.py: 95%
  - retry.py: 95%
- Dry-run on full 175-attack dataset: clean
- Live --sample 5 run: 5 successes, 5 cache writes, 48KB cache file
- LLM08 verified end-to-end on LLM08-0001: poisoned doc retrieved (distance 0.40 vs real docs 0.71-0.74), on-disk index unmodified

## Phase 4 implications (carried forward to IMPLEMENTATION_NOTES.md)

- The score-field rename to distance + similarity is breaking for any downstream consumer that reads results.jsonl. Document in Phase 4 plan.
- Stratified sampling distributes by category; --sample 5 only hits 5 of 10 categories. Use --sample 20 or --category for category-specific testing.
- Cache hits skip rate limiter and retry. Phase 4 evaluation runs against cached results will be near-instant.
